### PR TITLE
#57 Implement missing customer address api endpoint

### DIFF
--- a/BillBeeApiSDK.sln
+++ b/BillBeeApiSDK.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Billbee.Api.Client.Demo", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Billbee.Api.Client.Test", "Billbee.Api.Client.Test\Billbee.Api.Client.Test.csproj", "{3ADDE5CD-C642-476E-8ABA-6EC3031AE247}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Billbee.Api.Client.IntegrationTests", "Billbee.Api.Client.IntegrationTests\Billbee.Api.Client.IntegrationTests.csproj", "{846A92E2-C55B-4C80-8ACE-869E9E939189}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{3ADDE5CD-C642-476E-8ABA-6EC3031AE247}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3ADDE5CD-C642-476E-8ABA-6EC3031AE247}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3ADDE5CD-C642-476E-8ABA-6EC3031AE247}.Release|Any CPU.Build.0 = Release|Any CPU
+		{846A92E2-C55B-4C80-8ACE-869E9E939189}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{846A92E2-C55B-4C80-8ACE-869E9E939189}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{846A92E2-C55B-4C80-8ACE-869E9E939189}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{846A92E2-C55B-4C80-8ACE-869E9E939189}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Billbee.Api.Client.IntegrationTests/Billbee.Api.Client.IntegrationTests.csproj
+++ b/Billbee.Api.Client.IntegrationTests/Billbee.Api.Client.IntegrationTests.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Billbee.Api.Client\Billbee.Api.Client.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Billbee.Api.Client.IntegrationTests/EndPointTests/CustomerAddressesEndPointTests.cs
+++ b/Billbee.Api.Client.IntegrationTests/EndPointTests/CustomerAddressesEndPointTests.cs
@@ -1,0 +1,150 @@
+﻿using Billbee.Api.Client.Model;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Billbee.Api.Client.IntegrationTests.EndPointTests
+{
+    [Priority(1)]
+    [TestCaseOrderer(PriorityTestCaseOrderer.TypeName, PriorityTestCaseOrderer.AssemblyName)]
+    public class CustomerAddressesEndPointTests : IntegrationTestBase
+    {
+        private static long _randomCustomerId;
+        private static long _customerAddressId;
+        private static CustomerAddress? _updatedCustomerAddress;
+
+        [SkippableFact(DisplayName = "1. Can get a random customer"), Priority(0)]
+        public void CanGetRandomCustomer()
+        {
+            var getRandomCustomerResult = _apiClient.Customer.GetCustomerList(0, 1);
+            Assert.True(getRandomCustomerResult.Success);
+            Assert.NotEmpty(getRandomCustomerResult.Data);
+            var randomCustomerId = getRandomCustomerResult.Data.First().Id!.Value;
+            Assert.True(randomCustomerId > 0);
+
+            _randomCustomerId = randomCustomerId;
+        }
+
+        [SkippableFact(DisplayName = "2. Can create a customer address"), Priority(1)]
+        public void CanCreateCustomerAddress()
+        {
+            Skip.IfNot(_randomCustomerId > 0);
+
+            var createCustomerAddress = CreateRandomCustomerAddress(_randomCustomerId);
+
+            var addCustomerAddressResult = _apiClient.CustomerAddresses.AddCustomerAddresses(createCustomerAddress);
+            Assert.True(addCustomerAddressResult.Success);
+            Assert.NotNull(addCustomerAddressResult.Data);
+            Assert.True(addCustomerAddressResult.Data.Id > 0);
+            Assert_CustomerAddressEqual(createCustomerAddress, addCustomerAddressResult.Data);
+            _customerAddressId = addCustomerAddressResult.Data.Id!.Value;
+        }
+
+        [SkippableFact(DisplayName = "3. Can update the customer address"), Priority(2)]
+        public void CanUpdateCustomerAddress()
+        {
+            Skip.IfNot(_customerAddressId > 0);
+
+            var updateCustomerAddress = CreateRandomCustomerAddress(_randomCustomerId);
+            updateCustomerAddress.Id = _customerAddressId;
+            var updateCustomerAddressResult = _apiClient.CustomerAddresses.UpdateCustomerAddress(updateCustomerAddress);
+            Assert.True(updateCustomerAddressResult.Success);
+            Assert.NotNull(updateCustomerAddressResult.Data);
+            Assert_CustomerAddressEqual(updateCustomerAddress, updateCustomerAddressResult.Data);
+
+            _updatedCustomerAddress = updateCustomerAddress;
+        }
+
+        [SkippableFact(DisplayName = "4. Can get the updated customer address"), Priority(3)]
+        public void CanGetUpdatedCustomerAddress()
+        {
+            Skip.IfNot(_customerAddressId > 0);
+            Skip.If(_updatedCustomerAddress is null);
+
+            var getCustomerAddressResult = _apiClient.CustomerAddresses.GetCustomerAddress(_customerAddressId);
+            Assert.True(getCustomerAddressResult.Success);
+            Assert.NotNull(getCustomerAddressResult.Data);
+            Assert.Equal(_customerAddressId, getCustomerAddressResult.Data.Id);
+
+            Assert_CustomerAddressEqual(_updatedCustomerAddress, getCustomerAddressResult.Data);
+        }
+
+        [SkippableFact(DisplayName = "5. Can get the updared customer addresses from all addresses"), Priority(4)]
+        public void CanGetCustomerAddresses()
+        {
+            Skip.IfNot(_customerAddressId > 0);
+            Skip.If(_updatedCustomerAddress is null);
+
+            var totalPages = 2;
+            for (int page = 1; page <= totalPages; page++)
+            {
+                var getCustomerAddressesResult = _apiClient.CustomerAddresses.GetCustomerAddresses(page, 20);
+                Assert.True(getCustomerAddressesResult.Success);
+                Assert.NotNull(getCustomerAddressesResult.Data);
+                Assert.NotEmpty(getCustomerAddressesResult.Data);
+
+                var address = getCustomerAddressesResult.Data.FirstOrDefault(x => x.Id == _customerAddressId);
+                if (address is not null)
+                {
+                    Assert_CustomerAddressEqual(_updatedCustomerAddress, address);
+                    return;
+                }
+
+                totalPages = getCustomerAddressesResult.Paging.TotalPages;
+            }
+
+            throw new InvalidOperationException("Could not find created customer address in all addresses");
+        }
+
+        internal static CustomerAddress CreateRandomCustomerAddress(long randomCustomerId)
+        {
+            var random = new Random((int)DateTime.Now.Ticks);
+            return new CustomerAddress
+            {
+                AddressType = 1,
+                CustomerId = randomCustomerId,
+                Company = "Test Company " + Random(),
+                FirstName = "Test FirstName " + Random(),
+                LastName = "Test LastName " + Random(),
+                Name2 = "Test Name2 " + Random(),
+                Street = "Test Street " + Random(),
+                Housenumber = random.Next(1, 999).ToString(),
+                Zip = "44263",
+                City = "Test City " + Random(),
+                State = "Test State " + Random(),
+                CountryCode = "DE",
+                Email = Random() + "@test.invalid",
+                Tel1 = "0" + random.Next(1000000, 9000000),
+                Tel2 = "0" + random.Next(1000000, 9000000),
+                Fax = "0" + random.Next(1000000, 9000000),
+                AddressAddition = "Test AddressAddition " + Random()
+            };
+        }
+
+        private static void Assert_CustomerAddressEqual(CustomerAddress expected, CustomerAddress actual)
+        {
+            Assert.Equal(expected.AddressType, actual.AddressType);
+            Assert.Equal(expected.CustomerId, actual.CustomerId);
+            Assert.True(string.Equals(expected.Company, actual.Company, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.FirstName, actual.FirstName, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.LastName, actual.LastName, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Name2, actual.Name2, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Street, actual.Street, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Housenumber, actual.Housenumber, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Zip, actual.Zip, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.City, actual.City, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.State, actual.State, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.CountryCode, actual.CountryCode, StringComparison.InvariantCultureIgnoreCase));
+            //Assert.True(string.Equals(expected.Email, actual.Email, StringComparison.InvariantCultureIgnoreCase));
+            //Assert.True(string.Equals(expected.Tel1, actual.Tel1, StringComparison.InvariantCultureIgnoreCase));
+            //Assert.True(string.Equals(expected.Tel2, actual.Tel2, StringComparison.InvariantCultureIgnoreCase));
+            //Assert.True(string.Equals(expected.Fax, actual.Fax, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.AddressAddition, actual.AddressAddition, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static string Random()
+        {
+            return Guid.NewGuid().ToString()[24..];
+        }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/EndPointTests/CustomerEndPointTests.cs
+++ b/Billbee.Api.Client.IntegrationTests/EndPointTests/CustomerEndPointTests.cs
@@ -1,0 +1,88 @@
+﻿using Billbee.Api.Client.Model;
+using System;
+using Xunit;
+
+namespace Billbee.Api.Client.IntegrationTests.EndPointTests
+{
+    [Priority(0)]
+    [TestCaseOrderer(PriorityTestCaseOrderer.TypeName, PriorityTestCaseOrderer.AssemblyName)]
+    public class CustomerEndPointTests : IntegrationTestBase
+    {
+        private static long _customerId;
+        private static CustomerForCreation? _customer;
+
+        [SkippableFact(DisplayName = "1. Can create a random customer"), Priority(0)]
+        public void CanCreateCustomer()
+        {
+            var randomCustomer = CreateRandomCustomer();
+            var addCustomerResult = _apiClient.Customer.AddCustomer(randomCustomer);
+            Assert.True(addCustomerResult.Success);
+            Assert.NotNull(addCustomerResult.Data);
+            Assert.True(addCustomerResult.Data.Id > 0);
+            Assert_CustomerEqual(randomCustomer, addCustomerResult.Data);
+            _customerId = addCustomerResult.Data.Id!.Value;
+            _customer = randomCustomer;
+        }
+
+        [SkippableFact(DisplayName = "2. Can get the created customer"), Priority(1)]
+        public void CanGetCustomer()
+        {
+            Skip.IfNot(_customerId > 0);
+            Skip.If(_customer is null);
+
+            var getCustomerResult = _apiClient.Customer.GetCustomer(_customerId);
+            Assert.True(getCustomerResult.Success);
+            Assert.NotNull(getCustomerResult.Data);
+            Assert.True(getCustomerResult.Data.Id > 0);
+            Assert_CustomerEqual(_customer, getCustomerResult.Data);
+            _customerId = getCustomerResult.Data.Id!.Value;
+        }
+
+        private static CustomerForCreation CreateRandomCustomer()
+        {
+            var random = new Random((int)DateTime.Now.Ticks);
+            return new CustomerForCreation
+            {
+                Name = "Test " + Random(),
+                Email = Random() + "@test.de",
+                Tel1 = "0" + random.Next(1000000, 9000000),
+                Tel2 = "0" + random.Next(1000000, 9000000),
+                Type = 0,
+                Address = new CustomerAddress
+                {
+                    AddressType = 1,
+                    CustomerId = 0,
+                    Company = "Test Company " + Random(),
+                    FirstName = "Test FirstName " + Random(),
+                    LastName = "Test LastName " + Random(),
+                    Name2 = "Test Name2 " + Random(),
+                    Street = "Test Street " + Random(),
+                    Housenumber = random.Next(1, 999).ToString(),
+                    Zip = "44263",
+                    City = "Test City " + Random(),
+                    State = "Test State " + Random(),
+                    CountryCode = "DE",
+                    Email = Random() + "@test.invalid",
+                    Tel1 = "0" + random.Next(1000000, 9000000),
+                    Tel2 = "0" + random.Next(1000000, 9000000),
+                    Fax = "0" + random.Next(1000000, 9000000),
+                    AddressAddition = "Test AddressAddition " + Random()
+                }
+            };
+        }
+
+        private static void Assert_CustomerEqual(Customer expected, Customer actual)
+        {
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.True(string.Equals(expected.Name, actual.Name, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Email, actual.Email, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Tel1, actual.Tel1, StringComparison.InvariantCultureIgnoreCase));
+            Assert.True(string.Equals(expected.Tel2, actual.Tel2, StringComparison.InvariantCultureIgnoreCase));
+        }
+
+        private static string Random()
+        {
+            return Guid.NewGuid().ToString()[24..];
+        }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/Helper/CustomTestCaseOrderer.cs
+++ b/Billbee.Api.Client.IntegrationTests/Helper/CustomTestCaseOrderer.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Billbee.Api.Client.IntegrationTests.Helper
+{
+    internal class CustomTestCaseOrderer
+    {
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/Helper/PriorityAttribute.cs
+++ b/Billbee.Api.Client.IntegrationTests/Helper/PriorityAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Billbee.Api.Client.IntegrationTests
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = false)]
+    public class PriorityAttribute : Attribute
+    {
+        public PriorityAttribute(int priority)
+        {
+            Priority = priority;
+        }
+
+        public int Priority { get; private set; }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/Helper/PriorityTestCaseOrderer.cs
+++ b/Billbee.Api.Client.IntegrationTests/Helper/PriorityTestCaseOrderer.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Billbee.Api.Client.IntegrationTests
+{
+
+    public class PriorityTestCaseOrderer : ITestCaseOrderer
+    {
+        internal const string TypeName = "Billbee.Api.Client.IntegrationTests." + nameof(PriorityTestCaseOrderer);
+        internal const string AssemblyName = "Billbee.Api.Client.IntegrationTests";
+
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+        {
+            return testCases
+                .Select(testCase => (
+                    testCase,
+                    priority: GetPriority(testCase)
+                ))
+                .OrderBy(x => x.priority)
+                .Select(x => x.testCase)
+                .ToList()
+                ;
+        }
+
+        private static int GetPriority(ITestCase testCase)
+        {
+            return testCase.TestMethod.Method
+                .GetCustomAttributes(typeof(PriorityAttribute).AssemblyQualifiedName)
+                .Select(attributeInfo => attributeInfo.GetNamedArgument<int>(nameof(PriorityAttribute.Priority)))
+                .DefaultIfEmpty(int.MinValue)
+                .FirstOrDefault();
+        }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/Helper/PriorityTestCollectionOrderer.cs
+++ b/Billbee.Api.Client.IntegrationTests/Helper/PriorityTestCollectionOrderer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Billbee.Api.Client.IntegrationTests
+{
+    public class PriorityTestCollectionOrderer : ITestCollectionOrderer
+    {
+        internal const string TypeName = "Billbee.Api.Client.IntegrationTests." + nameof(PriorityTestCollectionOrderer);
+        internal const string AssemblyName = "Billbee.Api.Client.IntegrationTests";
+
+        public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+        {
+            return testCollections
+                .Select(testCollection => (
+                    testCollection,
+                    priority: GetPriority(testCollection)
+                ))
+                .OrderBy(x => x.priority)
+                .Select(x => x.testCollection)
+                .ToList()
+                ;
+        }
+
+        /// <summary>
+        /// Test collections are not bound to a specific class, however they
+        /// are named by default with the type name as a suffix. We try to
+        /// get the class name from the DisplayName and then use reflection to
+        /// find the class and OrderAttribute.
+        /// </summary>
+        private static int GetPriority(
+            ITestCollection testCollection)
+        {
+            var i = testCollection.DisplayName.LastIndexOf(' ');
+            if (i <= -1)
+            {
+                return int.MinValue;
+            }
+
+            var className = testCollection.DisplayName.Substring(i + 1);
+            var type = Type.GetType(className);
+            if (type is null)
+            {
+                return int.MinValue;
+            }
+
+            var attr = type.GetCustomAttribute<PriorityAttribute>();
+            return attr?.Priority ?? int.MinValue;
+        }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/IntegrationTestBase.cs
+++ b/Billbee.Api.Client.IntegrationTests/IntegrationTestBase.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Billbee.Api.Client.IntegrationTests
+{
+    public abstract class IntegrationTestBase
+    {
+        protected IApiClient _apiClient;
+
+        public IntegrationTestBase()
+        {
+            _apiClient = new ApiClient("settings.json");
+
+            if (string.IsNullOrWhiteSpace(_apiClient.Configuration.Username) ||
+                string.IsNullOrWhiteSpace(_apiClient.Configuration.Username) ||
+                string.IsNullOrWhiteSpace(_apiClient.Configuration.Password) ||
+                string.IsNullOrWhiteSpace(_apiClient.Configuration.ApiKey))
+            {
+                throw new InvalidOperationException("Please adjust the configuration file `settings.json` before test execution.");
+            }
+        }
+    }
+}

--- a/Billbee.Api.Client.IntegrationTests/TestOrderConfiguration.cs
+++ b/Billbee.Api.Client.IntegrationTests/TestOrderConfiguration.cs
@@ -1,0 +1,7 @@
+﻿using Billbee.Api.Client.IntegrationTests;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: TestCollectionOrderer(
+    PriorityTestCollectionOrderer.TypeName,
+    PriorityTestCollectionOrderer.AssemblyName)] 

--- a/Billbee.Api.Client.IntegrationTests/settings.json
+++ b/Billbee.Api.Client.IntegrationTests/settings.json
@@ -1,0 +1,5 @@
+﻿{
+  "Username": "",
+  "Password": "",
+  "ApiKey": ""
+}

--- a/Billbee.Api.Client/ApiClient.cs
+++ b/Billbee.Api.Client/ApiClient.cs
@@ -46,6 +46,8 @@ namespace Billbee.Api.Client
 
         public ICustomerEndPoint Customer => new CustomerEndPoint(_restClient);
 
+        public ICustomerAddressesEndPoint CustomerAddresses => new CustomerAddressesEndPoint(_restClient);
+
         public ISearchEndPoint Search => new SearchEndPoint(_restClient);
 
         public IOrderEndPoint Orders => new OrderEndPoint(_restClient);

--- a/Billbee.Api.Client/Billbee.Api.Client.csproj
+++ b/Billbee.Api.Client/Billbee.Api.Client.csproj
@@ -16,10 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="EndPoint" />
-    </ItemGroup>
-
-    <ItemGroup>
       <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="RestSharp" Version="106.12.0" />

--- a/Billbee.Api.Client/Endpoint/CustomerAddressesEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/CustomerAddressesEndPoint.cs
@@ -1,0 +1,50 @@
+﻿using Billbee.Api.Client.Endpoint.Interfaces;
+using Billbee.Api.Client.Model;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Billbee.Api.Client.EndPoint
+{
+    /// <inheritdoc cref="Billbee.Api.Client.Endpoint.Interfaces.ICustomerAddressesEndPoint" />
+    public class CustomerAddressesEndPoint : ICustomerAddressesEndPoint
+    {
+        private readonly IBillbeeRestClient _restClient;
+
+        internal CustomerAddressesEndPoint(IBillbeeRestClient restClient)
+        {
+            _restClient = restClient;
+        }
+
+        public ApiPagedResult<List<CustomerAddress>> GetCustomerAddresses(int page, int pageSize)
+        {
+            var parameters = new NameValueCollection
+            {
+                { "page", page.ToString() },
+                { "pageSize", pageSize.ToString() }
+            };
+
+            return _restClient.Get<ApiPagedResult<List<CustomerAddress>>>("/customer-addresses", parameters);
+        }
+
+        public ApiResult<CustomerAddress> GetCustomerAddress(long customerAddressId)
+        {
+            return _restClient.Get<ApiResult<CustomerAddress>>($"/customer-addresses/{customerAddressId}");
+        }
+
+        public ApiResult<CustomerAddress> AddCustomerAddresses(CustomerAddress customerAddress)
+        {
+            return _restClient.Post<ApiResult<CustomerAddress>>("/customer-addresses", customerAddress);
+        }
+
+        public ApiResult<CustomerAddress> UpdateCustomerAddress(CustomerAddress customerAddress)
+        {
+            if(customerAddress.Id == null || customerAddress.Id <= 0)
+            {
+                throw new InvalidOperationException("For an update operation a Customer-Address-ID must be provided.");
+            }
+
+            return _restClient.Put<ApiResult<CustomerAddress>>($"/customer-addresses/{customerAddress.Id.Value}", customerAddress);
+        }
+    }
+}

--- a/Billbee.Api.Client/Endpoint/Interfaces/ICustomerAddressesEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/Interfaces/ICustomerAddressesEndPoint.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Billbee.Api.Client.Model;
+
+namespace Billbee.Api.Client.Endpoint.Interfaces
+{
+    /// <summary>
+    /// Endpoint to access customer addresses
+    /// </summary>
+    public interface ICustomerAddressesEndPoint
+    {
+        /// <summary>
+        /// Queries a list of customers addresses
+        /// </summary>
+        /// <param name="page">page number</param>
+        /// <param name="pageSize">page size</param>
+        /// <returns>List of customers on the given page.</returns>
+        ApiPagedResult<List<CustomerAddress>> GetCustomerAddresses(int page, int pageSize);
+
+        /// <summary>
+        /// Gets a single customer address by its id
+        /// <param name="customerAddressId">customer address id</param>
+        /// </summary>
+        ApiResult<CustomerAddress> GetCustomerAddress(long customerAddressId);
+
+        /// <summary>
+        /// Creates a new customer address
+        /// <param name="customerAddress">customer address model</param>
+        /// </summary>
+        ApiResult<CustomerAddress> AddCustomerAddresses(CustomerAddress customerAddress);
+
+        /// <summary>
+        /// Updates a new customer address
+        /// </summary>
+        /// <param name="customerAddress">customer address model</param>
+        ApiResult<CustomerAddress> UpdateCustomerAddress(CustomerAddress customerAddress);
+    }
+}

--- a/Billbee.Api.Client/IApiClient.cs
+++ b/Billbee.Api.Client/IApiClient.cs
@@ -45,6 +45,11 @@ namespace Billbee.Api.Client
         ICustomerEndPoint Customer { get; }
 
         /// <summary>
+        /// EndPoint to access customer addresses
+        /// </summary>
+        ICustomerAddressesEndPoint CustomerAddresses { get; }
+
+        /// <summary>
         /// EndPoint for searches in customers, orders and products
         /// </summary>
         ISearchEndPoint Search { get; }


### PR DESCRIPTION
Hey Billbee maintainers!
The customer address end point #56 ist missing. Our customer needs this end point, so we are temporarily working with a custom build. I hope you benefit from this pull request in #57 and can quickly provide a new supported nuget client.

The basics requirements to implement integration test are also implemented. Of cause I added  the integration tests for the new endpoint. I hope the integration test are self explaining. Please try it out!

On your main branch the project file 'Billbee.Api.Client.Test.csproj' is missing, so I do not implemented units tests yet. 

I have tried to copy your code style (look and feel). Feel free to edit and adjust my code to you company preferences.

TODOs
[ ] Unit Tests
    Project file is currently missing
[ ] Missing Mappings
    Currently the address has fields that can be written, but are NULL when read:  Email, Tel1, Tel2, Fax