### PR TITLE
Fixed endpoint for ShipmentWithLabel

### DIFF
--- a/Billbee.Api.Client/Endpoint/ShipmentEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/ShipmentEndPoint.cs
@@ -28,7 +28,7 @@ namespace Billbee.Api.Client.EndPoint
 
         public ApiResult<ShipmentWithLabelResult> ShipOrderWithLabel(ShipmentWithLabel shipmentRequest)
         {
-            return _restClient.Post<ApiResult<ShipmentWithLabelResult>>("/shipment/shipment", shipmentRequest);
+            return _restClient.Post<ApiResult<ShipmentWithLabelResult>>("/shipment/shipwithlabel", shipmentRequest);
         }
         
         public List<ShippingCarrier> GetShippingCarriers()


### PR DESCRIPTION
I fixed the ShipmentWithLabel endpoint from "/shipment/shipment" to "/shipment/shipwithlabel" as I mentioned in #59 
