### PR TITLE
Added OrderAddress model for addresses in Order

### DIFF
--- a/Billbee.Api.Client/Model/Order.cs
+++ b/Billbee.Api.Client/Model/Order.cs
@@ -91,12 +91,12 @@ namespace Billbee.Api.Client.Model
         /// <summary>
         /// Addressee of the invoice
         /// </summary>
-        public Address InvoiceAddress { get; set; }
+        public OrderAddress InvoiceAddress { get; set; }
 
         /// <summary>
         /// Addressee, where the order was/is shipped to
         /// </summary>
-        public Address ShippingAddress { get; set; }
+        public OrderAddress ShippingAddress { get; set; }
 
         /// <summary>
         /// The payment method, used to pay this order

--- a/Billbee.Api.Client/Model/OrderAddress.cs
+++ b/Billbee.Api.Client/Model/OrderAddress.cs
@@ -1,0 +1,53 @@
+﻿namespace Billbee.Api.Client.Model
+{
+    /// <summary>
+    /// Basic address for usage in orders
+    /// </summary>
+    public class OrderAddress
+    {
+        /// <summary>
+        /// Internal id of this address
+        /// </summary>
+        public string BillbeeId { get; set; }
+
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public string Company { get; set; }
+
+        public string NameAddition { get; set; }
+
+        public string Street { get; set; }
+
+        public string HouseNumber { get; set; }
+
+        public string Zip { get; set; }
+
+        public string City { get; set; }
+
+        /// <summary>
+        /// The ISO 2 code of the country
+        /// </summary>
+        public string CountryISO2 { get; set; }
+
+        /// <summary>
+        /// Name of the country
+        /// </summary>
+        public string Country { get; set; }
+
+        public string Line2 { get; set; }
+
+        /// <summary>
+        /// E-mail address of an addressee, used for notification purposes.
+        /// </summary>
+        public string Email { get; set; }
+
+        public string State { get; set; }
+
+        /// <summary>
+        /// Phone number of an addressee, used for notification purposes.
+        /// </summary>
+        public string Phone { get; set; }
+    }
+}


### PR DESCRIPTION
The Order.ShippingAddress is using the Address-Model. Not all fields of an address are present on the order address model or named differently.

According to the Swagger definition, the field is called BillbeeId and not Id.
There is no field called Comment or Line3.

Issue #75 