### PR TITLE
Fix Address model

### DIFF
--- a/Billbee.Api.Client/Model/Address.cs
+++ b/Billbee.Api.Client/Model/Address.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Internal id of this address
         /// </summary>
-        public string BillbeeId { get; set; }
+        public long BillbeeId { get; set; }
 
         public string City { get; set; }
         public string Street { get; set; }


### PR DESCRIPTION
This PR fixes the following error on PostNewOrder endpoint.

```
HTTP/1.1 400 Bad Request
cache-control: no-cache
pragma: no-cache
content-type: application/json; charset=utf-8
expires: -1
x-ua-compatible: IE=edge
x-frame-options: SAMEORIGIN
reqtiming: 206
date: Wed, 09 Nov 2022 11:22:13 GMT
content-length: 361
connection: close

{
  "Message": "Die Anforderung ist ungültig.",
  "ModelState": {
    "orderData.InvoiceAddress.BillbeeId": [
      "Error converting value {null} to type 'System.Int64'. Path 'InvoiceAddress.BillbeeId', line 27, position 21."
    ],
    "orderData.ShippingAddress.BillbeeId": [
      "Error converting value {null} to type 'System.Int64'. Path 'ShippingAddress.BillbeeId', line 44, position 21."
    ]
  }
}
```