### PR TITLE
Change GetOrder method to only accept numeric IDs

### DIFF
--- a/Billbee.Api.Client.Test/EndPointTests/OrderEndPointTest.cs
+++ b/Billbee.Api.Client.Test/EndPointTests/OrderEndPointTest.cs
@@ -16,7 +16,7 @@ public class OrderEndPointTest
     public void Order_GetOrder_Test()
     {
         var testOrder = new Order();
-        var id = "4711";
+        var id = 4711;
         var articleTitleSource = 0;
         
         Expression<Func<IBillbeeRestClient, object>> expression = x => x.Get<ApiResult<Order>>($"/orders/{id}?articleTitleSource={articleTitleSource}", null);

--- a/Billbee.Api.Client/Endpoint/Interfaces/IOrderEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/Interfaces/IOrderEndPoint.cs
@@ -16,7 +16,7 @@ namespace Billbee.Api.Client.Endpoint.Interfaces
         /// <param name="id">id to search for</param>
         /// <param name="articleTitleSource">The source field for the article title. 0 = Order Position (default), 1 = Article Title, 2 = Article Invoice Text</param>
         /// <returns>Details of the order</returns>
-        ApiResult<Order> GetOrder(string id, int articleTitleSource = 0);
+        ApiResult<Order> GetOrder(long id, int articleTitleSource = 0);
 
         /// <summary>
         /// Gets a list of all fileds, that can be patched at an order.

--- a/Billbee.Api.Client/Endpoint/OrderEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/OrderEndPoint.cs
@@ -19,7 +19,7 @@ namespace Billbee.Api.Client.EndPoint
         }
 
         [ApiMapping("/api/v1/orders/{id}", HttpOperation.Get)]
-        public ApiResult<Order> GetOrder(string id, int articleTitleSource = 0)
+        public ApiResult<Order> GetOrder(long id, int articleTitleSource = 0)
         {
             return _restClient.Get<ApiResult<Order>>($"/orders/{id}?articleTitleSource={articleTitleSource}");
         }


### PR DESCRIPTION
The API only allows a numeric ID for the GetOrder endpoint. The SDK has been adjusted accordingly.