### PR TITLE
Separate billbee orderId from shipment orderId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,7 @@
 
 /packages
 /.vs/BillBeeApiSDK/v15
-/Billbee.Api.Client/bin/Debug
-/Billbee.Api.Client/obj/Debug
-/Billbee.Api.Client.Demo/bin/Debug
-/Billbee.Api.Client.Demo/obj/Debug
 /Billbee.Api.Client.Demo/Config.json
-/Billbee.Api.Client/obj/Release
-/Billbee.Api.Client.Demo/obj/Release
 /.vs
+bin/
+obj/

--- a/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
+++ b/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
-        <PackageVersion>2.4.4.0</PackageVersion>
+        <PackageVersion>2.5.1.0</PackageVersion>
         <Title>Billbee.Api.Client.Demo</Title>
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.4.0</AssemblyVersion>
-        <FileVersion>2.4.4.0</FileVersion>
+        <AssemblyVersion>2.5.1.0</AssemblyVersion>
+        <FileVersion>2.5.1.0</FileVersion>
         <Description>The Billbee API SDK for .Net</Description>
         <RepositoryUrl>https://github.com/billbeeio/billbee-csharp-sdk</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
+++ b/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
@@ -3,13 +3,13 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <PackageVersion>2.4.3.0</PackageVersion>
+        <PackageVersion>2.4.4.0</PackageVersion>
         <Title>Billbee.Api.Client.Demo</Title>
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.3.0</AssemblyVersion>
-        <FileVersion>2.4.3.0</FileVersion>
+        <AssemblyVersion>2.4.4.0</AssemblyVersion>
+        <FileVersion>2.4.4.0</FileVersion>
         <Description>The Billbee API SDK for .Net</Description>
         <RepositoryUrl>https://github.com/billbeeio/billbee-csharp-sdk</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
+++ b/Billbee.Api.Client.Demo/Billbee.Api.Client.Demo.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <PackageVersion>2.4.4.0</PackageVersion>
         <Title>Billbee.Api.Client.Demo</Title>
         <Authors>Billbee GmbH</Authors>

--- a/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
+++ b/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
@@ -8,8 +8,8 @@
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.4.0</AssemblyVersion>
-        <FileVersion>2.4.4.0</FileVersion>
+        <AssemblyVersion>2.5.1.0</AssemblyVersion>
+        <FileVersion>2.5.1.0</FileVersion>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
+++ b/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Title>Billbee.Api.Client.Test</Title>

--- a/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
+++ b/Billbee.Api.Client.Test/Billbee.Api.Client.Test.csproj
@@ -8,8 +8,8 @@
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.3.0</AssemblyVersion>
-        <FileVersion>2.4.3.0</FileVersion>
+        <AssemblyVersion>2.4.4.0</AssemblyVersion>
+        <FileVersion>2.4.4.0</FileVersion>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Billbee.Api.Client.Test/EndPointIntegrationTests/OrderEndPointIntegrationTest.cs
+++ b/Billbee.Api.Client.Test/EndPointIntegrationTests/OrderEndPointIntegrationTest.cs
@@ -185,18 +185,18 @@ namespace Billbee.Api.Client.Test.EndPointIntegrationTests
             var carrier = CrudHelpers.GetAll(() => IntegrationTestHelpers.ApiClient.Shipment.GetShippingCarriers())
                 .First();
             
-            var order = _createOrder();            
+            var order = _createOrder();
             Assert.IsNotNull(order.BillBeeOrderId);
             var orderShipment = new OrderShipment
             {
                 Comment = "comment",
                 CarrierId = carrier.Id,
-                OrderId = order.BillBeeOrderId.Value,
+                OrderId = order.BillBeeOrderId.Value.ToString(),
                 ShippingId = "123",
                 ShippingProviderId = provider.id,
                 ShippingProviderProductId = productId
             };
-            IntegrationTestHelpers.ApiClient.Orders.AddShipment(orderShipment);
+            IntegrationTestHelpers.ApiClient.Orders.AddShipment(order.BillBeeOrderId.Value, orderShipment);
         }
 
         [TestMethod]

--- a/Billbee.Api.Client.Test/EndPointTests/OrderEndPointTest.cs
+++ b/Billbee.Api.Client.Test/EndPointTests/OrderEndPointTest.cs
@@ -254,14 +254,15 @@ public class OrderEndPointTest
     [TestMethod]
     public void Order_AddShipment_Test()
     {
+        var orderId = 4711;
         var testOrderShipment = new OrderShipment();
         
-        Expression<Func<IBillbeeRestClient, object>> expression = x => x.Post($"/orders/{testOrderShipment.OrderId}/shipment", testOrderShipment);
+        Expression<Func<IBillbeeRestClient, object>> expression = x => x.Post($"/orders/{orderId}/shipment", testOrderShipment);
         object mockResult = null!;
         TestHelpers.RestClientMockTest(expression, mockResult, (restClient) =>
         {
             var uut = new OrderEndPoint(restClient);
-            uut.AddShipment(testOrderShipment);
+            uut.AddShipment(orderId, testOrderShipment);
         });
     }
     

--- a/Billbee.Api.Client/Billbee.Api.Client.csproj
+++ b/Billbee.Api.Client/Billbee.Api.Client.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <PackageVersion>2.4.4.0</PackageVersion>
+        <PackageVersion>2.5.1.0</PackageVersion>
         <Title>Billbee.Api.Client</Title>
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.4.0</AssemblyVersion>
-        <FileVersion>2.4.4.0</FileVersion>
+        <AssemblyVersion>2.5.1.0</AssemblyVersion>
+        <FileVersion>2.5.1.0</FileVersion>
         <Description>Client SDK for the Billbee API</Description>
         <RepositoryUrl>https://github.com/billbeeio/billbee-csharp-sdk</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Billbee.Api.Client/Billbee.Api.Client.csproj
+++ b/Billbee.Api.Client/Billbee.Api.Client.csproj
@@ -2,13 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <PackageVersion>2.4.3.0</PackageVersion>
+        <PackageVersion>2.4.4.0</PackageVersion>
         <Title>Billbee.Api.Client</Title>
         <Authors>Billbee GmbH</Authors>
         <Copyright>Copyright©, 2026 by Billbee GmbH</Copyright>
         <Company>Billbee GmbH</Company>
-        <AssemblyVersion>2.4.3.0</AssemblyVersion>
-        <FileVersion>2.4.3.0</FileVersion>
+        <AssemblyVersion>2.4.4.0</AssemblyVersion>
+        <FileVersion>2.4.4.0</FileVersion>
         <Description>Client SDK for the Billbee API</Description>
         <RepositoryUrl>https://github.com/billbeeio/billbee-csharp-sdk</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/Billbee.Api.Client/Endpoint/Interfaces/IOrderEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/Interfaces/IOrderEndPoint.cs
@@ -137,8 +137,9 @@ namespace Billbee.Api.Client.Endpoint.Interfaces
         /// <summary>
         /// Add a shipment, that was created in an external system to an order.
         /// </summary>
+        /// <param name="orderId">Id of the order</param>
         /// <param name="shipment"></param>
-        void AddShipment(OrderShipment shipment);
+        void AddShipment(long orderId, OrderShipment shipment);
 
         /// <summary>
         /// Requests the delivery note information for the given order.

--- a/Billbee.Api.Client/Endpoint/OrderEndPoint.cs
+++ b/Billbee.Api.Client/Endpoint/OrderEndPoint.cs
@@ -220,9 +220,9 @@ namespace Billbee.Api.Client.EndPoint
         }
         
         [ApiMapping("/api/v1/orders/{id}/shipment", HttpOperation.Post)]
-        public void AddShipment(OrderShipment shipment)
+        public void AddShipment(long orderId, OrderShipment shipment)
         {
-            _restClient.Post($"/orders/{shipment.OrderId}/shipment", shipment);
+            _restClient.Post($"/orders/{orderId}/shipment", shipment);
         }
 
         [ApiMapping("/api/v1/orders/CreateDeliveryNote/{id}", HttpOperation.Post)]

--- a/Billbee.Api.Client/Model/OrderShipment.cs
+++ b/Billbee.Api.Client/Model/OrderShipment.cs
@@ -11,9 +11,9 @@
         public string ShippingId { get; set; }
 
         /// <summary>
-        /// The id of the order, this shipment should be attached to
+        /// If applicable, the order id assigned by the shipping provider
         /// </summary>
-        public long OrderId { get; set; }
+        public string OrderId { get; set; }
 
         /// <summary>
         /// A note, that should be attached to the shipment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get an API key, send a mail to [support@billbee.de](mailto:support@billbee.de
 Download this package and decompress the solution to a place of your choice.
 If you don't want to compile by yourself, feel free, to use our NuGet package.
 ```Bash
-PM> Install-Package Billbee.Api.Client -Version 2.4.3
+PM> Install-Package Billbee.Api.Client -Version 2.4.4
 ```
 
 ## Official API Documentation

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get an API key, send a mail to [support@billbee.de](mailto:support@billbee.de
 Download this package and decompress the solution to a place of your choice.
 If you don't want to compile by yourself, feel free, to use our NuGet package.
 ```Bash
-PM> Install-Package Billbee.Api.Client -Version 2.4.4
+PM> Install-Package Billbee.Api.Client -Version 2.5.1
 ```
 
 ## Official API Documentation


### PR DESCRIPTION
Explicitly pass the billbee orderId to keep it separate from the shipment order id when adding a shipment for an order (https://app.billbee.io/swagger/ui/index#/Orders/OrderApi_AddShipment).

Previously the billbee orderId was always entered as "Auftragsnummer" in billbee which could have unintended consequences. This behavior of the API was also confimed by your support: "OrderId: Auftragsnummer des Versanddienstleisters (bei DHL gleich der Sendungsnummer)"

Now the user can still enter this field but also leave it empty, which reflects the same behavior as directly via the API.  Tested it on my billbee account and everything seems fine.

Also updated the target framework of the test and demo project to net8.0 as net 6.0 is already out of support.